### PR TITLE
Infix a postfix regex

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from subconjuntos import subconjuntos
 from simulacion import simulacion_AFD, simulacion_AFN
 from thompson import Thompson
+from postfix import InfixToPostfix, readExp
 
 x = True
 r = "(b|b)*abb(a|b)*"

--- a/postfix.py
+++ b/postfix.py
@@ -1,0 +1,69 @@
+exp = []
+operators = ['*', '|', '.', '(', ')']
+ops = {'*': 3, '.': 2, '|': 1}
+
+
+#Función necesaria para leer la expresión regular y agregar los operadores de concatenación
+def readExp():
+    infix = []
+    abc = [] 
+    symbols = ['*', '|', '(', ')']
+    exp = input('Ingrese la expresion regular: \n')
+    exp2 = ''
+    for e in exp:
+        infix.append(e)
+        if e not in symbols and e not in abc:
+            abc.append(e)
+    size = len(infix)
+    kleene = False
+    waiting  = 0
+    while size > 0:
+        if size > 1:
+            v1 = infix[size-1]
+            v2 = infix[size-2]
+            if kleene:
+                if waiting > 0:
+                    waiting -= 1
+                    kleene = False                    
+                    waiting = 0
+            elif v1 == '*' and not kleene:
+                kleene = True
+                waiting = 1
+            if (v1 == '(' and v2 in abc and not kleene) or (v1 in abc and v2 == ')' and not kleene) or (v1 in abc and v2 in abc and not kleene) or (v1 == '(' and v2 == ')' and not kleene) or (v1 in abc and v2 == '*' and not kleene) or (v1 == '(' and v2 == '*' and not kleene):
+                exp2 = '.' + v1 + exp2
+            else:
+                exp2 = v1 + exp2
+            size -= 1
+        else:
+            v1 = infix[size-1]
+            exp2 = v1 + exp2
+            size -= 1
+    #exp2 = exp2 + '.#'
+    return exp2
+
+#Basado en el algortimo de Shunting-yard
+def InfixToPostfix(exp):
+    OpStack = []
+    postfix = []
+    for e in exp:
+        #If the input symbol is a letter… append it directly to the output queue
+        if e not in operators:
+            postfix.append(e)
+        else:
+            if e == '(':
+                OpStack.append(e)
+            elif e == ')' and OpStack[-1] != '(' and len(OpStack) > 0:
+                while OpStack[-1] != '(':
+                    postfix.append(OpStack.pop())
+                OpStack.pop()
+            else:
+                if len(OpStack) > 0:
+                    while len(OpStack) > 0 and OpStack[-1] != '(' and ops[e] <= ops[OpStack[-1]]:
+                        postfix.append(OpStack.pop())
+                OpStack.append(e)
+    while len(OpStack) > 0:
+        postfix.append(OpStack.pop())
+    postfix.append('#')
+    postfix.append('.')
+    exp_postfix = ''.join(postfix)
+    return exp_postfix


### PR DESCRIPTION
Se importan las funciones necesarias para pasar una expresión regular a su formato postfix. El archivo que contiene ambas funciones se llama postfix. Este contiene una función que inserta los símbolos de concatenación necesarios para funcionar y otra que, siguiendo el algoritmo de Shunting-yard, pasa la expresión regular a su equivalente postfix. Esta última función es muy sensible a la presencia de paréntesis.